### PR TITLE
Revisit `mappers`

### DIFF
--- a/src/__tests__/mapObs.test.js
+++ b/src/__tests__/mapObs.test.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import Rx from 'rxjs';
 import {mount, shallow} from 'enzyme';
-import {compose, mapObs} from '../';
+import {compose, mapObs, mapPropsStream} from '../';
 
 describe('mapObs', () => {
   it('should emit props$.next when component receive props', () => {
+    // TODO: move this to 'mapPropsStream.test.js'.
     const propsSpy = jest.fn();
-    const Div = mapObs(({props$}) => ({props$: props$.do(propsSpy)}))('div');
+    const Div = mapPropsStream(props$ => props$.do(propsSpy))('div');
 
     const wrapper = shallow(<Div className="bar" />);
 
@@ -20,8 +21,9 @@ describe('mapObs', () => {
   });
 
   it('should take new props from props$', () => {
-    const Div = mapObs(
-      ({props$}) => ({props$: props$.map(({strings}) => ({className: strings.join('')}))}),
+    // TODO: move this to 'mapPropsStream.test.js'.
+    const Div = mapPropsStream(
+      props$ => props$.map(({strings}) => ({className: strings.join('')})),
     )('div');
 
     shallow(<Div strings={['a', 'b', 'c']} />);
@@ -30,7 +32,7 @@ describe('mapObs', () => {
   it('should unsubscribe props$ when unmount', () => {
     const props$ = new Rx.BehaviorSubject({});
     const propsSpy = jest.fn();
-    const Div = mapObs(() => ({props$: props$.do(propsSpy)}))('div');
+    const Div = mapPropsStream(() => props$.do(propsSpy))('div');
     const wrapper = shallow(<Div />);
     expect(propsSpy).toHaveBeenCalledTimes(1);
 
@@ -40,11 +42,12 @@ describe('mapObs', () => {
   });
 
   it('props$ should throw errors', () => {
+    // TODO: move this to 'mapPropsStream.test.js'.
     const props$ = new Rx.BehaviorSubject({});
 
-    const Div = mapObs(() => ({props$: props$.map(() => {
+    const Div = mapPropsStream(() => props$.map(() => {
       throw new Error('Too bad');
-    })}))('div');
+    }))('div');
 
     expect(() => {
       shallow(<Div />);
@@ -55,7 +58,7 @@ describe('mapObs', () => {
     const baseFoo$ = Rx.Observable.of({className: 'foo'});
     const Div = compose(
       mapObs(() => ({foo$: baseFoo$})),
-      mapObs(({foo$}) => ({props$: foo$})),
+      mapPropsStream((props$, {foo$}) => foo$),
     )('div');
 
     const wrapper = mount(<Div />);

--- a/src/__tests__/withObs.test.js
+++ b/src/__tests__/withObs.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Rx from 'rxjs';
 import {mount, shallow} from 'enzyme';
-import {compose, withObs} from '../';
+import {compose, withObs, mapPropsStream} from '../';
 
 describe('withObs', () => {
   it('should merge observables', () => {
@@ -9,7 +9,7 @@ describe('withObs', () => {
     const Component = compose(
       withObs(() => ({foo$: baseFoo$})),
       withObs(() => ({})),
-      withObs(({foo$}) => ({props$: foo$})),
+      mapPropsStream((props$, {foo$}) => foo$),
     )('div');
 
     const wrapper = mount(<Component />);
@@ -20,7 +20,7 @@ describe('withObs', () => {
     const baseFoo$ = Rx.Observable.of({className: 'foo'});
     const Component = compose(
       withObs({foo$: baseFoo$}),
-      withObs(({foo$}) => ({props$: foo$})),
+      mapPropsStream((props$, {foo$}) => foo$),
     )('div');
 
     const wrapper = mount(<Component />);

--- a/src/connectObs.js
+++ b/src/connectObs.js
@@ -3,7 +3,7 @@ import {combineLatest} from 'rxjs/observable/combineLatest';
 import {map} from 'rxjs/operator/map';
 import {startWith} from 'rxjs/operator/startWith';
 import createHelper from './createHelper';
-import withObs from './withObs';
+import withPropsStream from './withPropsStream';
 
 const checkObsMap = (obsMap) => {
   if (process.env.NODE_ENV !== 'production') {
@@ -40,8 +40,9 @@ const checkObservable = (observable, name) => {
 
 const aggregateProps = values => values.reduce((acc, value) => ({...acc, ...value}));
 
-const connectObs = mapObservables => withObs((observables) => {
-  const obsMap = mapObservables(observables);
+const connectObs = obsMapper => withPropsStream((props$, obs) => {
+  // TODO: change the interface of obsMapper. Should be `obsMapper(obs, props$)`.
+  const obsMap = obsMapper({...obs, ...props$});
   checkObsMap(obsMap);
 
   const combinedObs = Object.keys(obsMap).reduce((acc, key) => {
@@ -60,9 +61,9 @@ const connectObs = mapObservables => withObs((observables) => {
       ...acc,
       propsObservable::map(value => ({[key]: value})),
     ];
-  }, [observables.props$]);
+  }, []);
 
-  return {props$: combineLatest(combinedObs)::map(aggregateProps)};
+  return combineLatest(combinedObs)::map(aggregateProps);
 });
 
 export default createHelper(connectObs, 'connectObs');

--- a/src/mapObs.js
+++ b/src/mapObs.js
@@ -1,83 +1,11 @@
-/* eslint-disable no-console */
-import {Component, PropTypes} from 'react';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
-import createEagerFactory from 'recompose/createEagerFactory';
+import invariant from './utils/invariant';
+import createHoCFromMapper from './utils/createHoCFromMapper';
 import createHelper from './createHelper';
-import createSymbol from './utils/createSymbol';
 
-const throwError = (error) => {
-  throw error;
-};
+const mapObs = obsMapper => createHoCFromMapper((props$, obs) => {
+  const nextObs = obsMapper(obs, props$);
+  invariant(typeof nextObs === 'object', 'Expected a map of Observervables.');
+  return [props$, nextObs];
+});
 
-const MAPPERS_INFO = createSymbol('mappersInfo');
-const OBSERVABLES = createSymbol('observables');
-
-const createComponentFromMappers = (mappers, childFactory) =>
-  class extends Component {
-    static [MAPPERS_INFO] = {mappers, childFactory};
-    static contextTypes = {[OBSERVABLES]: PropTypes.object};
-    static childContextTypes = {[OBSERVABLES]: PropTypes.object};
-
-    props$ = new BehaviorSubject(this.props);
-
-    getChildContext() {
-      return this.childContext;
-    }
-
-    componentWillMount() {
-      const {
-        props$: childProps$,
-        ...childObservables
-      } = mappers.reduce(
-        (observables, mapper) => ({
-          props$: this.props$,
-          ...mapper(observables),
-        }),
-        {
-          ...this.context[OBSERVABLES],
-          props$: this.props$,
-        },
-      );
-
-      this.subscription = childProps$.subscribe({
-        next: childProps => this.setState({childProps}),
-        error: throwError,
-      });
-
-      this.childContext = {[OBSERVABLES]: childObservables};
-    }
-
-    componentWillReceiveProps(nextProps) {
-      this.props$.next(nextProps);
-    }
-
-    componentWillUnmount() {
-      this.subscription.unsubscribe();
-    }
-
-    shouldComponentUpdate(nextProps, nextState) {
-      return this.state.childProps !== nextState.childProps;
-    }
-
-    render() {
-      if (!this.state.childProps) {
-        return null;
-      }
-
-      return this.constructor[MAPPERS_INFO].childFactory(this.state.childProps);
-    }
-  };
-
-export default createHelper(mapper => (BaseComponent) => {
-  if (BaseComponent[MAPPERS_INFO]) {
-    return createComponentFromMappers(
-      [mapper, ...BaseComponent[MAPPERS_INFO].mappers],
-      BaseComponent[MAPPERS_INFO].childFactory,
-    );
-  }
-
-  return createComponentFromMappers(
-    [mapper],
-    createEagerFactory(BaseComponent),
-  );
-}, 'mapObs');
+export default createHelper(mapObs, 'mapObs');

--- a/src/mapPropsStream.js
+++ b/src/mapPropsStream.js
@@ -1,6 +1,11 @@
-import withObs from './withObs';
+import invariant from './utils/invariant';
+import createHoCFromMapper from './utils/createHoCFromMapper';
 import createHelper from './createHelper';
 
-const mapPropsStream = mapper => withObs(({props$}) => ({props$: mapper(props$)}));
+const mapPropsStream = propsStreamMapper => createHoCFromMapper((props$, obs) => {
+  const nextProps$ = propsStreamMapper(props$, obs);
+  invariant(typeof nextProps$.subscribe === 'function', 'Expected a props Observable.');
+  return [nextProps$, obs];
+});
 
 export default createHelper(mapPropsStream, 'mapPropsStream');

--- a/src/utils/createHoCFromMapper.js
+++ b/src/utils/createHoCFromMapper.js
@@ -1,0 +1,75 @@
+/* eslint-disable no-console */
+import {Component, PropTypes} from 'react';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import createEagerFactory from 'recompose/createEagerFactory';
+import createSymbol from './createSymbol';
+
+const throwError = (error) => {
+  throw error;
+};
+
+const MAPPERS_INFO = createSymbol('mappersInfo');
+const OBSERVABLES = createSymbol('observables');
+const CONTEXT_TYPES = {[OBSERVABLES]: PropTypes.object};
+
+const createComponentFromMappers = (mappers, childFactory) =>
+  class extends Component {
+    static [MAPPERS_INFO] = {mappers, childFactory};
+    static contextTypes = CONTEXT_TYPES;
+    static childContextTypes = CONTEXT_TYPES;
+
+    props$ = new BehaviorSubject(this.props);
+
+    getChildContext() {
+      return this.childContext;
+    }
+
+    componentWillMount() {
+      const [childProps$, childObservables] =
+        mappers.reduce(
+          ([props$, obs], mapper) => mapper(props$, obs),
+          [this.props$, this.context[OBSERVABLES]],
+        );
+
+      this.childPropsSubscription = childProps$.subscribe({
+        next: childProps => this.setState({childProps}),
+        error: throwError,
+      });
+
+      this.childContext = {[OBSERVABLES]: childObservables};
+    }
+
+    componentWillReceiveProps(nextProps) {
+      this.props$.next(nextProps);
+    }
+
+    componentWillUnmount() {
+      this.childPropsSubscription.unsubscribe();
+    }
+
+    shouldComponentUpdate(nextProps, nextState) {
+      return this.state.childProps !== nextState.childProps;
+    }
+
+    render() {
+      if (!this.state.childProps) {
+        return null;
+      }
+
+      return this.constructor[MAPPERS_INFO].childFactory(this.state.childProps);
+    }
+  };
+
+export default mapper => (BaseComponent) => {
+  if (BaseComponent[MAPPERS_INFO]) {
+    return createComponentFromMappers(
+      [mapper, ...BaseComponent[MAPPERS_INFO].mappers],
+      BaseComponent[MAPPERS_INFO].childFactory,
+    );
+  }
+
+  return createComponentFromMappers(
+    [mapper],
+    createEagerFactory(BaseComponent),
+  );
+};

--- a/src/utils/invariant.js
+++ b/src/utils/invariant.js
@@ -1,0 +1,8 @@
+export default (condition, message) => {
+  if (!condition) {
+    const error = new Error(message);
+    error.framesToPop = 1; // Discard the invariant's own frame.
+
+    throw error;
+  }
+};

--- a/src/utils/wrap.js
+++ b/src/utils/wrap.js
@@ -1,0 +1,5 @@
+export default fn => (...args) => (
+  typeof fn === 'function'
+    ? fn(...args)
+    : fn
+);

--- a/src/withHandlers.js
+++ b/src/withHandlers.js
@@ -1,7 +1,7 @@
-import {map} from 'rxjs/operator/map';
+import {mapTo} from 'rxjs/operator/mapTo';
 import {_do} from 'rxjs/operator/do';
 import createHelper from './createHelper';
-import mapPropsStream from './mapPropsStream';
+import withPropsStream from './withPropsStream';
 
 const mapValues = (obj, fn) =>
   Object.keys(obj).reduce((result, key) => {
@@ -9,7 +9,7 @@ const mapValues = (obj, fn) =>
     return result;
   }, {});
 
-const withHandlers = handlerFactories => mapPropsStream((props$) => {
+const withHandlers = handlerFactories => withPropsStream((props$) => {
   let cachedHandlers;
   let props;
 
@@ -41,7 +41,7 @@ const withHandlers = handlerFactories => mapPropsStream((props$) => {
     },
   );
 
-  return props$::_do(onNextProps)::map(nextProps => ({...nextProps, ...handlers}));
+  return props$::_do(onNextProps)::mapTo(handlers);
 });
 
 export default createHelper(withHandlers, 'withHandlers');

--- a/src/withObs.js
+++ b/src/withObs.js
@@ -1,14 +1,10 @@
+import wrap from './utils/wrap';
 import createHelper from './createHelper';
 import mapObs from './mapObs';
 
-const withObs = input =>
-  mapObs(observables => ({
-    ...observables,
-    ...(
-      typeof input === 'function'
-        ? input(observables)
-        : input
-    ),
-  }));
+const withObs = obsMapper => mapObs((obs, props$) => ({
+  ...obs,
+  ...wrap(obsMapper)(obs, props$),
+}));
 
 export default createHelper(withObs, 'withObs');

--- a/src/withProps.js
+++ b/src/withProps.js
@@ -1,14 +1,8 @@
+import {map} from 'rxjs/operator/map';
 import createHelper from './createHelper';
-import mapProps from './mapProps';
+import withPropsStream from './withPropsStream';
+import wrap from './utils/wrap';
 
-const withProps = input =>
-  mapProps(props => ({
-    ...props,
-    ...(
-      typeof input === 'function'
-        ? input(props)
-        : input
-    ),
-  }));
+const withProps = propsMapper => withPropsStream(props$ => props$::map(wrap(propsMapper)));
 
 export default createHelper(withProps, 'withProps');

--- a/src/withPropsStream.js
+++ b/src/withPropsStream.js
@@ -1,0 +1,16 @@
+import {withLatestFrom} from 'rxjs/operator/withLatestFrom';
+import wrap from './utils/wrap';
+import invariant from './utils/invariant';
+import mapPropsStream from './mapPropsStream';
+import createHelper from './createHelper';
+
+const withPropsStream = propsStreamMapper => mapPropsStream((props$, obs) => {
+  const nextProps$ = wrap(propsStreamMapper)(props$, obs);
+  invariant(typeof nextProps$.subscribe === 'function', 'Expected a props Observable.');
+  return nextProps$::withLatestFrom(props$, (nextProps, props) => ({
+    ...props,
+    ...nextProps,
+  }));
+});
+
+export default createHelper(withPropsStream, 'withPropsStream');


### PR DESCRIPTION
A `mapper` (in the Recompact sense) is a function that has the following signature:

    (props$: Observable, obsMap: {[string]: Observable, ...}) =>
      [Observable, {[string]: Observable, ...}]

This changeset makes it the smallest atom of Recompact's architecture.

@neoziro: If this resonates with you, let me know and I'll had a bunch of tests.